### PR TITLE
Aws tg attachement instances

### DIFF
--- a/aws/resource_aws_alb_target_group_attachment.go
+++ b/aws/resource_aws_alb_target_group_attachment.go
@@ -17,6 +17,7 @@ func resourceAwsAlbTargetGroupAttachment() *schema.Resource {
 		Create: resourceAwsAlbAttachmentCreate,
 		Read:   resourceAwsAlbAttachmentRead,
 		Delete: resourceAwsAlbAttachmentDelete,
+		Update: resourceAwsAlbAttachmentUpdate,
 
 		Schema: map[string]*schema.Schema{
 			"target_group_arn": {
@@ -28,7 +29,7 @@ func resourceAwsAlbTargetGroupAttachment() *schema.Resource {
 			"target_id": {
 				Type:     schema.TypeString,
 				ForceNew: true,
-				Required: true,
+				Optional: true,
 			},
 
 			"port": {
@@ -36,28 +37,129 @@ func resourceAwsAlbTargetGroupAttachment() *schema.Resource {
 				ForceNew: true,
 				Optional: true,
 			},
+
+			"instances": &schema.Schema{
+				Type:     schema.TypeSet,
+				ForceNew: false,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+				Computed: true,
+				Set:      schema.HashString,
+			},
 		},
 	}
+}
+
+func resourceAwsAlbAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Update Target  %s (%d) with Target Group %s", d.Get("target_id").(string),
+		d.Get("port").(int), d.Get("target_group_arn").(string))
+
+	elbconn := meta.(*AWSClient).elbv2conn
+
+	if _, ok := d.GetOk("instances"); !ok {
+		log.Printf("[ERROR] Call update and instances is empty for Target Group %s", d.Get("target_group_arn").(string))
+		return nil
+	}
+
+	resp, err := elbconn.DescribeTargetHealth(&elbv2.DescribeTargetHealthInput{
+		TargetGroupArn: aws.String(d.Get("target_group_arn").(string)),
+	})
+
+	if err != nil {
+		return errwrap.Wrapf("Error reading Target Health: {{err}}", err)
+	}
+
+	targets := d.Get("instances").(*schema.Set)
+
+	paramsDereg := &elbv2.DeregisterTargetsInput{
+		TargetGroupArn: aws.String(d.Get("target_group_arn").(string)),
+	}
+
+	for _, targetDeployed := range resp.TargetHealthDescriptions {
+		log.Printf("[DEBUG] Look for targets to remove from target group : current loop %s", *(targetDeployed.Target.Id))
+
+		//Target deployed not in  given in the resource  -> remove it
+		if !targets.Contains(*(targetDeployed.Target.Id)) {
+			targetPortToAdd := &elbv2.TargetDescription{
+				Id: aws.String(*(targetDeployed.Target.Id)),
+			}
+			if v, ok := d.GetOk("port"); ok {
+				targetPortToAdd.Port = aws.Int64(int64(v.(int)))
+			}
+			paramsDereg.Targets = append(paramsDereg.Targets, targetPortToAdd)
+
+		}
+	}
+
+	if len(paramsDereg.Targets) > 0 {
+		log.Printf("[DEBUG] %d target to remove from %s", len(paramsDereg.Targets), d.Get("target_group_arn").(string))
+		_, err = elbconn.DeregisterTargets(paramsDereg)
+		if err != nil {
+			return errwrap.Wrapf("Error deregistering Targets: {{err}}", err)
+		}
+	}
+
+	//Get the ID from the TargetHealthDescription
+	thd := make(map[string]bool)
+	for _, v := range resp.TargetHealthDescriptions {
+		thd[*(v.Target.Id)] = true
+	}
+	paramsRegister := &elbv2.RegisterTargetsInput{
+		TargetGroupArn: aws.String(d.Get("target_group_arn").(string)),
+	}
+	for _, target := range targets.List() {
+		if _, ok := thd[target.(string)]; !ok {
+			targetPortToAdd := &elbv2.TargetDescription{
+				Id: aws.String(target.(string)),
+			}
+			if v, ok := d.GetOk("port"); ok {
+				targetPortToAdd.Port = aws.Int64(int64(v.(int)))
+			}
+			paramsRegister.Targets = append(paramsRegister.Targets, targetPortToAdd)
+		}
+	}
+	if len(paramsRegister.Targets) > 0 {
+		log.Printf("[DEBUG] %d target to add to %s", len(paramsRegister.Targets), d.Get("target_group_arn").(string))
+		_, err = elbconn.RegisterTargets(paramsRegister)
+		if err != nil {
+			return errwrap.Wrapf("Error registering targets with target group: {{err}}", err)
+		}
+	}
+	return nil
 }
 
 func resourceAwsAlbAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbv2conn
 
-	target := &elbv2.TargetDescription{
-		Id: aws.String(d.Get("target_id").(string)),
-	}
-
-	if v, ok := d.GetOk("port"); ok {
-		target.Port = aws.Int64(int64(v.(int)))
-	}
-
 	params := &elbv2.RegisterTargetsInput{
 		TargetGroupArn: aws.String(d.Get("target_group_arn").(string)),
-		Targets:        []*elbv2.TargetDescription{target},
 	}
 
-	log.Printf("[INFO] Registering Target %s with Target Group %s", d.Get("target_id").(string),
-		d.Get("target_group_arn").(string))
+	if _, ok := d.GetOk("target_id"); ok {
+		targetPortToAdd := &elbv2.TargetDescription{
+			Id: aws.String(d.Get("target_id").(string)),
+		}
+		if v, ok := d.GetOk("port"); ok {
+			targetPortToAdd.Port = aws.Int64(int64(v.(int)))
+		}
+
+		params.Targets = append(params.Targets, targetPortToAdd)
+		log.Printf("[INFO] Registering Target %s (%d) with Target Group %s", d.Get("target_id").(string),
+			d.Get("port").(int), d.Get("target_group_arn").(string))
+	} else {
+		targets := d.Get("instances").(*schema.Set)
+
+		for _, target := range targets.List() {
+			targetPortToAdd := &elbv2.TargetDescription{
+				Id: aws.String(target.(string)),
+			}
+			if v, ok := d.GetOk("port"); ok {
+				targetPortToAdd.Port = aws.Int64(int64(v.(int)))
+			}
+
+			params.Targets = append(params.Targets, targetPortToAdd)
+		}
+	}
 
 	_, err := elbconn.RegisterTargets(params)
 	if err != nil {
@@ -72,17 +174,34 @@ func resourceAwsAlbAttachmentCreate(d *schema.ResourceData, meta interface{}) er
 func resourceAwsAlbAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbv2conn
 
-	target := &elbv2.TargetDescription{
-		Id: aws.String(d.Get("target_id").(string)),
-	}
-
-	if v, ok := d.GetOk("port"); ok {
-		target.Port = aws.Int64(int64(v.(int)))
-	}
-
 	params := &elbv2.DeregisterTargetsInput{
 		TargetGroupArn: aws.String(d.Get("target_group_arn").(string)),
-		Targets:        []*elbv2.TargetDescription{target},
+	}
+
+	if _, ok := d.GetOk("target_id"); ok {
+		targetPortToAdd := &elbv2.TargetDescription{
+			Id: aws.String(d.Get("target_id").(string)),
+		}
+		if v, ok := d.GetOk("port"); ok {
+			targetPortToAdd.Port = aws.Int64(int64(v.(int)))
+		}
+
+		params.Targets = append(params.Targets, targetPortToAdd)
+		log.Printf("[INFO] Registering Target %s (%d) with Target Group %s", d.Get("target_id").(string),
+			d.Get("port").(int), d.Get("target_group_arn").(string))
+	} else {
+		targets := d.Get("instances").(*schema.Set)
+
+		for _, target := range targets.List() {
+			targetPortToAdd := &elbv2.TargetDescription{
+				Id: aws.String(target.(string)),
+			}
+			if v, ok := d.GetOk("port"); ok {
+				targetPortToAdd.Port = aws.Int64(int64(v.(int)))
+			}
+
+			params.Targets = append(params.Targets, targetPortToAdd)
+		}
 	}
 
 	_, err := elbconn.DeregisterTargets(params)
@@ -100,18 +219,37 @@ func resourceAwsAlbAttachmentDelete(d *schema.ResourceData, meta interface{}) er
 func resourceAwsAlbAttachmentRead(d *schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbv2conn
 
-	target := &elbv2.TargetDescription{
-		Id: aws.String(d.Get("target_id").(string)),
-	}
-
-	if v, ok := d.GetOk("port"); ok {
-		target.Port = aws.Int64(int64(v.(int)))
-	}
-
-	resp, err := elbconn.DescribeTargetHealth(&elbv2.DescribeTargetHealthInput{
+	params := &elbv2.DescribeTargetHealthInput{
 		TargetGroupArn: aws.String(d.Get("target_group_arn").(string)),
-		Targets:        []*elbv2.TargetDescription{target},
-	})
+	}
+
+	if _, ok := d.GetOk("target_id"); ok {
+		targetPortToAdd := &elbv2.TargetDescription{
+			Id: aws.String(d.Get("target_id").(string)),
+		}
+		if v, ok := d.GetOk("port"); ok {
+			targetPortToAdd.Port = aws.Int64(int64(v.(int)))
+		}
+		params.Targets = append(params.Targets, targetPortToAdd)
+		log.Printf("[INFO] Registering Target %s (%d) with Target Group %s", d.Get("target_id").(string),
+			d.Get("port").(int), d.Get("target_group_arn").(string))
+	} else {
+		targets := d.Get("instances").(*schema.Set)
+
+		for _, target := range targets.List() {
+			targetPortToAdd := &elbv2.TargetDescription{
+				Id: aws.String(target.(string)),
+			}
+			if v, ok := d.GetOk("port"); ok {
+				targetPortToAdd.Port = aws.Int64(int64(v.(int)))
+			}
+
+			params.Targets = append(params.Targets, targetPortToAdd)
+		}
+	}
+
+	resp, err := elbconn.DescribeTargetHealth(params)
+
 	if err != nil {
 		if isTargetGroupNotFound(err) {
 			log.Printf("[WARN] Target group does not exist, removing target attachment %s", d.Id())
@@ -126,7 +264,7 @@ func resourceAwsAlbAttachmentRead(d *schema.ResourceData, meta interface{}) erro
 		return errwrap.Wrapf("Error reading Target Health: {{err}}", err)
 	}
 
-	if len(resp.TargetHealthDescriptions) != 1 {
+	if len(resp.TargetHealthDescriptions) < 1 {
 		log.Printf("[WARN] Target does not exist, removing target attachment %s", d.Id())
 		d.SetId("")
 		return nil

--- a/aws/resource_aws_alb_target_group_attachment.go
+++ b/aws/resource_aws_alb_target_group_attachment.go
@@ -17,6 +17,7 @@ func resourceAwsAlbTargetGroupAttachment() *schema.Resource {
 		Create: resourceAwsAlbAttachmentCreate,
 		Read:   resourceAwsAlbAttachmentRead,
 		Delete: resourceAwsAlbAttachmentDelete,
+		Update: resourceAwsAlbAttachmentUpdate,
 
 		Schema: map[string]*schema.Schema{
 			"target_group_arn": {
@@ -28,7 +29,7 @@ func resourceAwsAlbTargetGroupAttachment() *schema.Resource {
 			"target_id": {
 				Type:     schema.TypeString,
 				ForceNew: true,
-				Required: true,
+				Optional: true,
 			},
 
 			"port": {
@@ -36,28 +37,133 @@ func resourceAwsAlbTargetGroupAttachment() *schema.Resource {
 				ForceNew: true,
 				Optional: true,
 			},
+
+			"instances": &schema.Schema{
+				Type:     schema.TypeSet,
+				ForceNew: false,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+				Computed: true,
+				Set:      schema.HashString,
+			},
 		},
 	}
+}
+
+func resourceAwsAlbAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Update Target  %s (%d) with Target Group %s", d.Get("target_id").(string),
+		d.Get("port").(int), d.Get("target_group_arn").(string))
+
+	elbconn := meta.(*AWSClient).elbv2conn
+
+	if _, ok := d.GetOk("instances"); !ok {
+		log.Printf("[ERROR] Call update and instances is empty for Target Group %s", d.Get("target_group_arn").(string))
+		return nil
+	}
+
+	resp, err := elbconn.DescribeTargetHealth(&elbv2.DescribeTargetHealthInput{
+		TargetGroupArn: aws.String(d.Get("target_group_arn").(string)),
+	})
+
+	if err != nil {
+		return errwrap.Wrapf("Error reading Target Health: {{err}}", err)
+	}
+
+	targets := d.Get("instances").(*schema.Set)
+
+	paramsDereg := &elbv2.DeregisterTargetsInput{
+		TargetGroupArn: aws.String(d.Get("target_group_arn").(string)),
+	}
+
+	for _, targetDeployed := range resp.TargetHealthDescriptions {
+<<<<<<< HEAD
+		log.Printf("[DEBUG] Look for targets to remove from target group : current loop %s", *(targetDeployed.Target.Id))
+=======
+		log.Printf("[DEBUG] Look for target to remove from target group : current loop %s", *(targetDeployed.Target.Id))
+>>>>>>> 8f215baf54f6b8e8174ccf6f7a9f4858f0531bb9
+
+		//Target deployed not in  given in the resource  -> remove it
+		if !targets.Contains(*(targetDeployed.Target.Id)) {
+			targetPortToAdd := &elbv2.TargetDescription{
+				Id: aws.String(*(targetDeployed.Target.Id)),
+			}
+			if v, ok := d.GetOk("port"); ok {
+				targetPortToAdd.Port = aws.Int64(int64(v.(int)))
+			}
+			paramsDereg.Targets = append(paramsDereg.Targets, targetPortToAdd)
+
+		}
+	}
+
+	if len(paramsDereg.Targets) > 0 {
+		log.Printf("[DEBUG] %d target to remove from %s", len(paramsDereg.Targets), d.Get("target_group_arn").(string))
+		_, err = elbconn.DeregisterTargets(paramsDereg)
+		if err != nil {
+			return errwrap.Wrapf("Error deregistering Targets: {{err}}", err)
+		}
+	}
+
+	//Get the ID from the TargetHealthDescription
+	thd := make(map[string]bool)
+	for _, v := range resp.TargetHealthDescriptions {
+		thd[*(v.Target.Id)] = true
+	}
+	paramsRegister := &elbv2.RegisterTargetsInput{
+		TargetGroupArn: aws.String(d.Get("target_group_arn").(string)),
+	}
+	for _, target := range targets.List() {
+		if _, ok := thd[target.(string)]; !ok {
+			targetPortToAdd := &elbv2.TargetDescription{
+				Id: aws.String(target.(string)),
+			}
+			if v, ok := d.GetOk("port"); ok {
+				targetPortToAdd.Port = aws.Int64(int64(v.(int)))
+			}
+			paramsRegister.Targets = append(paramsRegister.Targets, targetPortToAdd)
+		}
+	}
+	if len(paramsRegister.Targets) > 0 {
+		log.Printf("[DEBUG] %d target to add to %s", len(paramsRegister.Targets), d.Get("target_group_arn").(string))
+		_, err = elbconn.RegisterTargets(paramsRegister)
+		if err != nil {
+			return errwrap.Wrapf("Error registering targets with target group: {{err}}", err)
+		}
+	}
+	return nil
 }
 
 func resourceAwsAlbAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbv2conn
 
-	target := &elbv2.TargetDescription{
-		Id: aws.String(d.Get("target_id").(string)),
-	}
-
-	if v, ok := d.GetOk("port"); ok {
-		target.Port = aws.Int64(int64(v.(int)))
-	}
-
 	params := &elbv2.RegisterTargetsInput{
 		TargetGroupArn: aws.String(d.Get("target_group_arn").(string)),
-		Targets:        []*elbv2.TargetDescription{target},
 	}
 
-	log.Printf("[INFO] Registering Target %s with Target Group %s", d.Get("target_id").(string),
-		d.Get("target_group_arn").(string))
+	if _, ok := d.GetOk("target_id"); ok {
+		targetPortToAdd := &elbv2.TargetDescription{
+			Id: aws.String(d.Get("target_id").(string)),
+		}
+		if v, ok := d.GetOk("port"); ok {
+			targetPortToAdd.Port = aws.Int64(int64(v.(int)))
+		}
+
+		params.Targets = append(params.Targets, targetPortToAdd)
+		log.Printf("[INFO] Registering Target %s (%d) with Target Group %s", d.Get("target_id").(string),
+			d.Get("port").(int), d.Get("target_group_arn").(string))
+	} else {
+		targets := d.Get("instances").(*schema.Set)
+
+		for _, target := range targets.List() {
+			targetPortToAdd := &elbv2.TargetDescription{
+				Id: aws.String(target.(string)),
+			}
+			if v, ok := d.GetOk("port"); ok {
+				targetPortToAdd.Port = aws.Int64(int64(v.(int)))
+			}
+
+			params.Targets = append(params.Targets, targetPortToAdd)
+		}
+	}
 
 	_, err := elbconn.RegisterTargets(params)
 	if err != nil {
@@ -72,17 +178,34 @@ func resourceAwsAlbAttachmentCreate(d *schema.ResourceData, meta interface{}) er
 func resourceAwsAlbAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbv2conn
 
-	target := &elbv2.TargetDescription{
-		Id: aws.String(d.Get("target_id").(string)),
-	}
-
-	if v, ok := d.GetOk("port"); ok {
-		target.Port = aws.Int64(int64(v.(int)))
-	}
-
 	params := &elbv2.DeregisterTargetsInput{
 		TargetGroupArn: aws.String(d.Get("target_group_arn").(string)),
-		Targets:        []*elbv2.TargetDescription{target},
+	}
+
+	if _, ok := d.GetOk("target_id"); ok {
+		targetPortToAdd := &elbv2.TargetDescription{
+			Id: aws.String(d.Get("target_id").(string)),
+		}
+		if v, ok := d.GetOk("port"); ok {
+			targetPortToAdd.Port = aws.Int64(int64(v.(int)))
+		}
+
+		params.Targets = append(params.Targets, targetPortToAdd)
+		log.Printf("[INFO] Registering Target %s (%d) with Target Group %s", d.Get("target_id").(string),
+			d.Get("port").(int), d.Get("target_group_arn").(string))
+	} else {
+		targets := d.Get("instances").(*schema.Set)
+
+		for _, target := range targets.List() {
+			targetPortToAdd := &elbv2.TargetDescription{
+				Id: aws.String(target.(string)),
+			}
+			if v, ok := d.GetOk("port"); ok {
+				targetPortToAdd.Port = aws.Int64(int64(v.(int)))
+			}
+
+			params.Targets = append(params.Targets, targetPortToAdd)
+		}
 	}
 
 	_, err := elbconn.DeregisterTargets(params)
@@ -100,18 +223,37 @@ func resourceAwsAlbAttachmentDelete(d *schema.ResourceData, meta interface{}) er
 func resourceAwsAlbAttachmentRead(d *schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbv2conn
 
-	target := &elbv2.TargetDescription{
-		Id: aws.String(d.Get("target_id").(string)),
-	}
-
-	if v, ok := d.GetOk("port"); ok {
-		target.Port = aws.Int64(int64(v.(int)))
-	}
-
-	resp, err := elbconn.DescribeTargetHealth(&elbv2.DescribeTargetHealthInput{
+	params := &elbv2.DescribeTargetHealthInput{
 		TargetGroupArn: aws.String(d.Get("target_group_arn").(string)),
-		Targets:        []*elbv2.TargetDescription{target},
-	})
+	}
+
+	if _, ok := d.GetOk("target_id"); ok {
+		targetPortToAdd := &elbv2.TargetDescription{
+			Id: aws.String(d.Get("target_id").(string)),
+		}
+		if v, ok := d.GetOk("port"); ok {
+			targetPortToAdd.Port = aws.Int64(int64(v.(int)))
+		}
+		params.Targets = append(params.Targets, targetPortToAdd)
+		log.Printf("[INFO] Registering Target %s (%d) with Target Group %s", d.Get("target_id").(string),
+			d.Get("port").(int), d.Get("target_group_arn").(string))
+	} else {
+		targets := d.Get("instances").(*schema.Set)
+
+		for _, target := range targets.List() {
+			targetPortToAdd := &elbv2.TargetDescription{
+				Id: aws.String(target.(string)),
+			}
+			if v, ok := d.GetOk("port"); ok {
+				targetPortToAdd.Port = aws.Int64(int64(v.(int)))
+			}
+
+			params.Targets = append(params.Targets, targetPortToAdd)
+		}
+	}
+
+	resp, err := elbconn.DescribeTargetHealth(params)
+
 	if err != nil {
 		if isTargetGroupNotFound(err) {
 			log.Printf("[WARN] Target group does not exist, removing target attachment %s", d.Id())
@@ -126,7 +268,7 @@ func resourceAwsAlbAttachmentRead(d *schema.ResourceData, meta interface{}) erro
 		return errwrap.Wrapf("Error reading Target Health: {{err}}", err)
 	}
 
-	if len(resp.TargetHealthDescriptions) != 1 {
+	if len(resp.TargetHealthDescriptions) < 1 {
 		log.Printf("[WARN] Target does not exist, removing target attachment %s", d.Id())
 		d.SetId("")
 		return nil


### PR DESCRIPTION
Hi,

I have seen your PR on the terraform-provider-aws and as I was looking a solution to add instances a target group without deregistering/registering all the instances. I tested your fix on my infrastructure but I had errors because I don't specified the target port in the attachment.

So I fixed the issue with port and added an update function to avoid recreating the attachement at each change.

Regards,

grems6